### PR TITLE
feat(metadata-detail): Add support for complete stubs

### DIFF
--- a/src/metadata/metadata-detail.coffee
+++ b/src/metadata/metadata-detail.coffee
@@ -13,4 +13,10 @@ details =
   # Referenced schemes only include items used by the artefact to be returned.
   REFERENCE_PARTIAL: 'referencepartial'
 
+  # All artefacts are returned as complete stubs.
+  ALL_COMPLETE_STUBS: 'allcompletestubs'
+
+  # Referenced artefacts are returned as complete stubs.
+  REFERENCE_COMPLETE_STUBS: 'referencecompletestubs'
+
 exports.MetadataDetail = Object.freeze details

--- a/test/metadata/metadata-detail.test.coffee
+++ b/test/metadata/metadata-detail.test.coffee
@@ -9,6 +9,8 @@ describe 'Metadata detail', ->
     'referencestubs'
     'allstubs'
     'referencepartial'
+    'allcompletestubs'
+    'referencecompletestubs'
   ]
 
   it 'contains all the expected details and only those', ->


### PR DESCRIPTION
Adds the possibility to return complete stubs, i.e. stubs with description, annotations, and other
attributes like isFinal.

fix #59