### PR TITLE
feat(metadata-type): Add support for new constraints type

### DIFF
--- a/src/metadata/metadata-references.coffee
+++ b/src/metadata/metadata-references.coffee
@@ -28,10 +28,16 @@ references =
   # The combination of parentsandsiblings and descendants.
   ALL: 'all'
 
+excluded = [
+  'structure'
+  'actualconstraint'
+  'allowedconstraint'
+]
+
 # All the predefined SDMX types are valid references, except for the 'catch all'
 # `structure`
 ( ->
-  references[key] = val for key, val of MetadataType when val isnt 'structure'
+  references[key] = val for key, val of MetadataType when val not in excluded
 )()
 
 exports.MetadataReferences = Object.freeze references

--- a/src/metadata/metadata-type.coffee
+++ b/src/metadata/metadata-type.coffee
@@ -32,6 +32,8 @@ types =
   CATEGORISATION: 'categorisation'
   CONTENT_CONSTRAINT: 'contentconstraint'
   ATTACHMENT_CONSTRAINT: 'attachmentconstraint'
+  ACTUAL_CONSTRAINT: 'actualconstraint'
+  ALLOWED_CONSTRAINT: 'allowedconstraint'
   STRUCTURE: 'structure'
 
 exports.MetadataType = Object.freeze types

--- a/test/metadata/metadata-type.test.coffee
+++ b/test/metadata/metadata-type.test.coffee
@@ -25,6 +25,8 @@ describe 'Metadata types', ->
     'categorisation'
     'contentconstraint'
     'attachmentconstraint'
+    'actualconstraint'
+    'allowedconstraint'
     'structure'
   ]
 


### PR DESCRIPTION
A SDMX Content Constraint can have 2 distinct flavours – actual and allowable. This is now supported
in the API, thanks to the addition of 2 new REST resources: actualconstraint and allowedconstraint.

fix #57