### PR TITLE
fix(service): Wrong defaut version format for ECB service

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=6"
   },
   "description": "SDMX REST API client for JavaScript",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "main": "./lib/index.js",
   "scripts": {
     "prebuild": "rm -rf lib && mkdir lib",

--- a/src/service/service.coffee
+++ b/src/service/service.coffee
@@ -29,7 +29,7 @@ service = class Service
     name: 'European Central Bank'
     api: ApiVersion.v1_0_2
     url: 'http://sdw-wsrest.ecb.europa.eu/service'
-    format: DataFormat.SDMX_JSON
+    format: DataFormat.SDMX_JSON_1_0_0_WD
 
   @SDMXGR:
     id: 'SDMXGR'

--- a/test/service/service.test.coffee
+++ b/test/service/service.test.coffee
@@ -70,7 +70,7 @@ describe 'Service', ->
       Service[s].url.should.contain 'https' for s in i when s.indexOf('_S') > -1
 
     it 'offers a default format for some predefined services', ->
-      format = DataFormat.SDMX_JSON
+      format = DataFormat.SDMX_JSON_1_0_0_WD
       Service['ECB'].should.have.property('format').that.equals format
 
     it 'offers access to secure instances of predefined services', ->


### PR DESCRIPTION
The ECB web service supports the working draft version of SDMX-JSON and not the version recently
released by SDMX (i.e. SDMX-JSON, v1.0.0). Therefore, the additional data format added to version
2.9.0 of the library (released mid-October) broke the predefined ECB service.

Fix #cr-99