### PR TITLE
refactor(api): Rename checkFormat

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -47,7 +47,7 @@ isGenericFormat = (format) ->
   ]
   format in formats
 
-checkFormat = (response) ->
+checkMediaType = (response) ->
   fmt = response.headers.get('content-type')
   unless isDataFormat(fmt) or isMetadataFormat(fmt) or isGenericFormat(fmt)
     throw RangeError "Not an SDMX format: #{fmt}"
@@ -327,7 +327,7 @@ module.exports =
   request: request
   request2: request2
   checkStatus: checkStatus
-  checkFormat: checkFormat
+  checkMediaType: checkMediaType
   data:
     DataFormat: DataFormat
     DataDetail: DataDetail

--- a/test/index.test.coffee
+++ b/test/index.test.coffee
@@ -17,7 +17,7 @@ describe 'API', ->
     sdmxrest.should.have.property 'getUrl'
     sdmxrest.should.have.property 'request'
     sdmxrest.should.have.property 'checkStatus'
-    sdmxrest.should.have.property 'checkFormat'
+    sdmxrest.should.have.property 'checkMediaType'
     sdmxrest.should.have.property('data').that.is.an 'object'
     sdmxrest.should.have.property('metadata').that.is.an 'object'
     sdmxrest.should.have.property('availability').that.is.an 'object'
@@ -367,13 +367,13 @@ describe 'API', ->
         should.not.throw(test, RangeError, 'Request failed with error code 100')
       )
 
-  describe 'when using checkFormat()', ->
+  describe 'when using checkMediaType()', ->
     it 'accepts SDMX data formats', ->
       nock('http://sdw-wsrest.ecb.europa.eu')
         .get((uri) -> uri.indexOf('EXR') > -1)
         .reply 200, 'OK', {'Content-Type': 'application/vnd.sdmx.data+json;version=1.0.0'}
       sdmxrest.request2({flow: 'EXR', key: 'A.CHF.EUR.SP00.A'}, 'ECB').then((response) ->
-        test = -> sdmxrest.checkFormat(response)
+        test = -> sdmxrest.checkMediaType(response)
         should.not.throw(test, RangeError, 'Not an SDMX format')
       )
 
@@ -382,7 +382,7 @@ describe 'API', ->
         .get((uri) -> uri.indexOf('codelist') > -1)
         .reply 200, 'OK', {'Content-Type': 'application/vnd.sdmx.structure+xml;version=2.1'}
       sdmxrest.request2({resource: 'codelist'}, 'ECB').then((response) ->
-        test = -> sdmxrest.checkFormat(response)
+        test = -> sdmxrest.checkMediaType(response)
         should.not.throw(test, RangeError, 'Not an SDMX format')
       )
 
@@ -391,7 +391,7 @@ describe 'API', ->
         .get((uri) -> uri.indexOf('codelist') > -1)
         .reply 200, 'OK', {'Content-Type': 'application/xml'}
       sdmxrest.request2({resource: 'codelist'}, 'ECB').then((response) ->
-        test = -> sdmxrest.checkFormat(response)
+        test = -> sdmxrest.checkMediaType(response)
         should.not.throw(test, RangeError, 'Not an SDMX format')
       )
 
@@ -400,7 +400,7 @@ describe 'API', ->
         .get((uri) -> uri.indexOf('EXR') > -1)
         .reply 200, 'OK', {'Content-Type': 'application/vnd.test.data+json'}
       sdmxrest.request2({flow: 'EXR'}, 'ECB').then((response) ->
-        test = -> sdmxrest.checkFormat(response)
+        test = -> sdmxrest.checkMediaType(response)
         should.Throw(test, RangeError, 'Not an SDMX format: application/vnd.test.data+json'))
 
     it 'throws an error in case no format is specified', ->
@@ -408,5 +408,5 @@ describe 'API', ->
         .get((uri) -> uri.indexOf('EXR') > -1)
         .reply 200, 'OK'
       sdmxrest.request2({flow: 'EXR'}, 'ECB').then((response) ->
-        test = -> sdmxrest.checkFormat(response)
+        test = -> sdmxrest.checkMediaType(response)
         should.Throw(test, RangeError, 'Not an SDMX format: null'))


### PR DESCRIPTION
Function checkFormat() has been renamed to checkMediaType() to avoid giving the impression that the
message format is checked for validity.