### PR TITLE
fix(metadata-type): Mark reporting taxonomies as item schemes

### DIFF
--- a/src/metadata/metadata-type.coffee
+++ b/src/metadata/metadata-type.coffee
@@ -9,6 +9,7 @@ itemSchemes = [
   'dataconsumerscheme'
   'organisationunitscheme'
   'hierarchicalcodelist'
+  'reportingtaxonomy'
 ]
 
 types =

--- a/src/utils/api-version.coffee
+++ b/src/utils/api-version.coffee
@@ -25,7 +25,7 @@ versions =
   v1_3_0: 'v1.3.0'
 
 # The version of the SDMX RESTFul API released in June 2019. The release is
-# a minor one, merely adding a dedicated media type for SDMX-JSON structure 
+# a minor one, merely adding a dedicated media type for SDMX-JSON structure
 # messages.
   v1_4_0: 'v1.4.0'
 

--- a/test/metadata/metadata-type.test.coffee
+++ b/test/metadata/metadata-type.test.coffee
@@ -42,3 +42,6 @@ describe 'Metadata types', ->
 
   it 'considers hierarchicalcodelist as item scheme', ->
     isItemScheme('hierarchicalcodelist').should.be.true
+
+  it 'considers reportingtaxonomy as item scheme', ->
+    isItemScheme('reportingtaxonomy').should.be.true


### PR DESCRIPTION
Reporting taxonomies are item schemes, according to the SDMX information model. This was not
properly reported by the isItemScheme helper function.

fix #121