### PR TITLE
Fix GH Action Build Badge + Re-format Badge lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # sdmx-rest4js
-[![Build](https://github.com/sosna/sdmx-rest4js/workflows/Build/badge.svg)] [![codecov.io](https://codecov.io/github/sosna/sdmx-rest4js/coverage.svg?branch=master)](https://codecov.io/github/sosna/sdmx-rest4js?branch=master) [![Codacy Grade](https://api.codacy.com/project/badge/Grade/7adaf82b611d478882ad1471f02b4314)](https://www.codacy.com/project/sosna/sdmx-rest4js/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=sosna/sdmx-rest4js&amp;utm_campaign=Badge_Grade_Dashboard) [![Known Vulnerabilities](https://snyk.io/test/github/sosna/sdmx-rest4js/badge.svg?targetFile=package.json)](https://snyk.io/test/github/sosna/sdmx-rest4js?targetFile=package.json)  [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![current version](https://img.shields.io/npm/v/sdmx-rest.svg)](https://www.npmjs.com/package/sdmx-rest) [![Mentioned in Awesome Official Statistics ](https://awesome.re/mentioned-badge.svg)](http://www.awesomeofficialstatistics.org)
+
+[![Build](https://github.com/sosna/sdmx-rest4js/workflows/Build/badge.svg)](https://github.com/sosna/sdmx-rest4js/actions)
+[![codecov.io](https://codecov.io/github/sosna/sdmx-rest4js/coverage.svg?branch=master)](https://codecov.io/github/sosna/sdmx-rest4js?branch=master)
+[![Codacy Grade](https://api.codacy.com/project/badge/Grade/7adaf82b611d478882ad1471f02b4314)](https://www.codacy.com/project/sosna/sdmx-rest4js/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=sosna/sdmx-rest4js&amp;utm_campaign=Badge_Grade_Dashboard)
+[![Known Vulnerabilities](https://snyk.io/test/github/sosna/sdmx-rest4js/badge.svg?targetFile=package.json)](https://snyk.io/test/github/sosna/sdmx-rest4js?targetFile=package.json)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![current version](https://img.shields.io/npm/v/sdmx-rest.svg)](https://www.npmjs.com/package/sdmx-rest)
+[![Mentioned in Awesome Official Statistics ](https://awesome.re/mentioned-badge.svg)](http://www.awesomeofficialstatistics.org)
 
 
 This library allows to easily create and execute [SDMX REST queries](https://github.com/sdmx-twg/sdmx-rest) from a JavaScript client application.


### PR DESCRIPTION
## Change 1

The badge for GitHub Action Build is not well-formatted.

![sosna_sdmx-rest4js__SDMX_REST_API_client_for_JavaScript](https://user-images.githubusercontent.com/11539188/90548789-c762ca00-e18d-11ea-8373-07d2ebe82d2c.png)

Minor update is done to fix it, and add link to Actions page

## Change 2

Re-format the badge lines.
