### PR TITLE
Use build-in method for checking endsWith

### DIFF
--- a/src/utils/url-generator.coffee
+++ b/src/utils/url-generator.coffee
@@ -13,7 +13,7 @@ itemAllowed = (resource, api) ->
 createEntryPoint = (s) ->
   throw ReferenceError "#{s.url} is not a valid service" unless s.url
   url = s.url
-  url = s.url + '/' unless s.url.indexOf('/', s.url.length - 1) > -1
+  url = s.url + '/' unless s.url.endsWith('/')
   url
 
 createDataQuery = (query, service) ->


### PR DESCRIPTION
I assume using built-in string method `endsWith` serves the purpose here better by being more explicit (only given it's legal in CoffeeScript + my understanding is correct)